### PR TITLE
Refactored CC-24

### DIFF
--- a/components/StartGame/StartGame.js
+++ b/components/StartGame/StartGame.js
@@ -74,8 +74,8 @@ class StartGame extends Component {
     optionName === OptionsEnum.SCORE ? this.setState({ chosenScore: value }) :
     optionName === OptionsEnum.WEIGHT ? this.setState({ chosenWeightMissed: value }) :
     optionName === OptionsEnum.LINE ? this.setState({ chosenLineMissed: value }) :
-    optionName === OptionsEnum.SWEEP_ERROR ? this.setState({ sweepMissed: value }) :
-    optionName === OptionsEnum.LINE_ERROR ? this.setState({ lineMissed: value }) :
+    optionName === OptionsEnum.SWEEP_ERROR ? this.setState({ sweepError: value }) :
+    optionName === OptionsEnum.LINE_ERROR ? this.setState({ lineError: value }) :
     console.log('Cannot set radio button state.');
 
   // This function returns the value of the state selected so that we can update the radio button on the UI
@@ -85,8 +85,8 @@ class StartGame extends Component {
     optionName === OptionsEnum.SCORE ? this.state.chosenScore :
     optionName === OptionsEnum.WEIGHT ? this.state.chosenWeightMissed :
     optionName === OptionsEnum.LINE ? this.state.chosenLineMissed :
-    optionName === OptionsEnum.SWEEP_ERROR ? this.state.sweepMissed :
-    optionName === OptionsEnum.LINE_ERROR ? this.state.lineMissed :
+    optionName === OptionsEnum.SWEEP_ERROR ? this.state.sweepError :
+    optionName === OptionsEnum.LINE_ERROR ? this.state.lineError :
     console.log('Cannot return state.');
 
   renderRadioButtons = (option, optionName) => {

--- a/components/StartGame/StartGame.js
+++ b/components/StartGame/StartGame.js
@@ -1,51 +1,56 @@
 import React, { Component }  from 'react'
 import styles from "./Styles";
 import { ScrollView, View, Text } from 'react-native';
-import RadioForm from "react-native-simple-radio-button";
+import RadioForm, { RadioButtonLabel, RadioButton, RadioButtonInput } from "react-native-simple-radio-button";
+import { widthPercentageToDP as wp } from "react-native-responsive-screen";
 
-const changeLabelStyle = (labelText) => {
-  return (
-      <Text style={styles.labelText}>
-        {labelText}
-      </Text>
-    )
+const OptionsEnum = {
+  ROTATION: 'rotation',
+  SHOT_TYPE: 'shot type',
+  SCORE: 'score',
+  WEIGHT: 'weight',
+  LINE: 'line',
+  SWEEP_ERROR: 'sweep error',
+  LINE_ERROR: 'line error'
 };
+Object.freeze(OptionsEnum);
+
 
 const rotationOpts = [
-  { label: changeLabelStyle('In-turn'), value: 0 },
-  { label: changeLabelStyle('Out-turn'), value: 1 }
+  { label: 'In-turn', value: 0 },
+  { label: 'Out-turn', value: 1 }
 ];
 
 const shotTypeOpts = [
-  { label: changeLabelStyle('Guard'), value: 0 },
-  { label: changeLabelStyle('Draw'), value: 1 },
-  { label: changeLabelStyle('Hit'), value: 2 }
+  { label: 'Guard', value: 0 },
+  { label: 'Draw', value: 1 },
+  { label: 'Hit', value: 2 }
 ];
 
 const scoreOpts = [
-  { label: changeLabelStyle('0'), value: 0 },
-  { label: changeLabelStyle('1'), value: 1 },
-  { label: changeLabelStyle('2'), value: 2 },
-  { label: changeLabelStyle('3'), value: 3 },
-  { label: changeLabelStyle('4'), value: 4 },
+  { label: '0', value: 0 },
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 },
+  { label: '4', value: 4 },
 ];
 
 const missedWeightOpts = [
-  { label: changeLabelStyle('Light'), value: 0 },
-  { label: changeLabelStyle('Heavy'), value: 1 },
+  { label: 'Light', value: 0 },
+  { label: 'Heavy', value: 1 },
 ];
 
 const missedLineOpts = [
-  { label: changeLabelStyle('Inside'), value: 0 },
-  { label: changeLabelStyle('Wide'), value: 1 },
+  { label: 'Inside', value: 0 },
+  { label: 'Wide', value: 1 },
 ];
 
 const missedOther1Opts = [
-  { label: changeLabelStyle('Sweeping Error'), value: 0 },
+  { label: 'Sweeping Error', value: 0 },
 ];
 
 const missedOther2Opts = [
-  { label: changeLabelStyle('Line-call Error'), value: 0 },
+  { label: 'Line-call Error', value: 0 },
 ];
 
 class StartGame extends Component {
@@ -58,10 +63,71 @@ class StartGame extends Component {
       chosenScore: 0,
       chosenWeightMissed: 0,
       chosenLineMissed: 0,
-      sweepMissed: 0,
-      lineMissed: 0
+      sweepError: 0,
+      lineError: 0
     }
   }
+
+  handleRadioPress = (optionName, value) =>
+    optionName === OptionsEnum.ROTATION ? this.setState({ chosenRotation: value }) :
+    optionName === OptionsEnum.SHOT_TYPE ? this.setState({ chosenShotType: value }) :
+    optionName === OptionsEnum.SCORE ? this.setState({ chosenScore: value }) :
+    optionName === OptionsEnum.WEIGHT ? this.setState({ chosenWeightMissed: value }) :
+    optionName === OptionsEnum.LINE ? this.setState({ chosenLineMissed: value }) :
+    optionName === OptionsEnum.SWEEP_ERROR ? this.setState({ sweepMissed: value }) :
+    optionName === OptionsEnum.LINE_ERROR ? this.setState({ lineMissed: value }) :
+    console.log('Cannot set radio button state.');
+
+  // This function returns the value of the state selected so that we can update the radio button on the UI
+  returnSelectedState = (optionName) =>
+    optionName === OptionsEnum.ROTATION ? this.state.chosenRotation :
+    optionName === OptionsEnum.SHOT_TYPE ? this.state.chosenShotType :
+    optionName === OptionsEnum.SCORE ? this.state.chosenScore :
+    optionName === OptionsEnum.WEIGHT ? this.state.chosenWeightMissed :
+    optionName === OptionsEnum.LINE ? this.state.chosenLineMissed :
+    optionName === OptionsEnum.SWEEP_ERROR ? this.state.sweepMissed :
+    optionName === OptionsEnum.LINE_ERROR ? this.state.lineMissed :
+    console.log('Cannot return state.');
+
+  renderRadioButtons = (option, optionName) => {
+    return (
+      <RadioForm
+        formHorizontal={true}
+        animation={false}
+      >
+        {
+          option.map((obj, i) => (
+            <RadioButton
+              labelHorizontal={false}
+              key={i}
+            >
+              <RadioButtonInput
+                obj={obj}
+                index={i}
+                onPress={() => this.handleRadioPress(optionName, obj.value)}
+                isSelected={this.returnSelectedState(optionName) === i}
+                borderWidth={wp('.5%')}
+                buttonInnerColor={'#A0060F'}
+                buttonOuterColor={'#A0060F'}
+                buttonSize={wp('5%')}
+                buttonOuterSize={wp('7.4%')}
+                buttonStyle={{}}
+                buttonWrapStyle={{marginLeft: wp('2.5%')}}
+              />
+              <RadioButtonLabel
+                obj={obj}
+                index={i}
+                onPress={() => this.handleRadioPress(optionName, obj.value)}
+                labelHorizontal={true}
+                labelStyle={styles.labelText}
+                labelWrapStyle={{marginLeft: wp('1%')}}
+              />
+            </RadioButton>
+          ))
+        }
+      </RadioForm>
+    )
+  };
 
   render() {
     return (
@@ -71,20 +137,7 @@ class StartGame extends Component {
               <Text style={styles.optionText}>Rotation</Text>
            </View>
           <View style={styles.labelContainer}>
-            <RadioForm
-              radio_props={rotationOpts}
-              formHorizontal={true}
-              labelHorizontal={false}
-              animation={false}
-              buttonColor={"#A0060F"}
-              selectedButtonColor={"#A0060F"}
-              labelColor={'#FFFFFF'}
-              selectedLabelColor={'#FFFFFF'}
-              initial={0}
-              onPress={value => {
-                this.setState({chosenRotation: value});
-              }}
-            />
+            {this.renderRadioButtons(rotationOpts, OptionsEnum.ROTATION)}
           </View>
         </View>
           <View style={styles.optionContainer}>
@@ -92,20 +145,7 @@ class StartGame extends Component {
               <Text style={styles.optionText}>Shot Type</Text>
             </View>
             <View style={styles.labelContainer}>
-              <RadioForm
-                radio_props={shotTypeOpts}
-                formHorizontal={true}
-                labelHorizontal={false}
-                animation={false}
-                buttonColor={"#A0060F"}
-                selectedButtonColor={"#A0060F"}
-                labelColor={'#FFFFFF'}
-                selectedLabelColor={'#FFFFFF'}
-                initial={0}
-                onPress={value => {
-                  this.setState({chosenShotType: value});
-                }}
-              />
+              {this.renderRadioButtons(shotTypeOpts, OptionsEnum.SHOT_TYPE)}
             </View>
           </View>
           <View style={styles.optionContainer}>
@@ -113,20 +153,7 @@ class StartGame extends Component {
               <Text style={styles.optionText}>Score</Text>
             </View>
             <View style={styles.labelContainer}>
-              <RadioForm
-                radio_props={scoreOpts}
-                formHorizontal={true}
-                labelHorizontal={false}
-                animation={false}
-                buttonColor={"#A0060F"}
-                selectedButtonColor={"#A0060F"}
-                labelColor={'#FFFFFF'}
-                selectedLabelColor={'#FFFFFF'}
-                initial={0}
-                onPress={value => {
-                  this.setState({chosenScore: value});
-                }}
-              />
+              {this.renderRadioButtons(scoreOpts, OptionsEnum.SCORE)}
             </View>
           </View>
           <View style={styles.missedOptionContainer}>
@@ -136,76 +163,20 @@ class StartGame extends Component {
             <View style={styles.labelContainer}>
               <View style={styles.missedTitleContainer}>
                 <Text style={styles.missedOptionText}>Weight</Text>
-                <RadioForm
-                  radio_props={missedWeightOpts}
-                  formHorizontal={true}
-                  labelHorizontal={false}
-                  animation={false}
-                  buttonColor={"#A0060F"}
-                  selectedButtonColor={"#A0060F"}
-                  labelColor={'#FFFFFF'}
-                  selectedLabelColor={'#FFFFFF'}
-                  initial={0}
-                  onPress={value => {
-                    this.setState({chosenWeightMissed: value});
-                  }}
-                />
+                {this.renderRadioButtons(missedWeightOpts, OptionsEnum.WEIGHT)}
               </View>
             </View>
             <View style={styles.labelContainer}>
               <View style={styles.missedTitleContainer}>
                 <Text style={styles.missedOptionText}>Line</Text>
-                <RadioForm
-                  radio_props={missedLineOpts}
-                  formHorizontal={true}
-                  labelHorizontal={false}
-                  animation={false}
-                  buttonColor={"#A0060F"}
-                  selectedButtonColor={"#A0060F"}
-                  labelColor={'#FFFFFF'}
-                  selectedLabelColor={'#FFFFFF'}
-                  initial={0}
-                  onPress={value => {
-                    this.setState({chosenLineMissed: value});
-                  }}
-                />
+                {this.renderRadioButtons(missedLineOpts, OptionsEnum.LINE)}
               </View>
             </View>
             <View style={styles.labelContainer}>
               <View style={styles.missedTitleContainer}>
                 <Text style={styles.missedOptionText}>Other</Text>
-                <RadioForm
-                  radio_props={missedOther1Opts}
-                  formHorizontal={true}
-                  labelHorizontal={false}
-                  animation={false}
-                  buttonColor={"#A0060F"}
-                  selectedButtonColor={"#A0060F"}
-                  labelColor={'#FFFFFF'}
-                  selectedLabelColor={'#FFFFFF'}
-                  initial={-1}
-                  onPress={value => {
-                    if (value === 0) {
-                      this.setState({chosenOther1Missed: -1});
-                    } else {
-                      this.setState({chosenOther1Missed: value});
-                    }
-                  }}
-                />
-                <RadioForm
-                  radio_props={missedOther2Opts}
-                  formHorizontal={true}
-                  labelHorizontal={false}
-                  animation={false}
-                  buttonColor={"#A0060F"}
-                  selectedButtonColor={"#A0060F"}
-                  labelColor={'#FFFFFF'}
-                  selectedLabelColor={'#FFFFFF'}
-                  initial={-1}
-                  onPress={value => {
-                    this.setState({chosenOther2Missed: value});
-                  }}
-                />
+                {this.renderRadioButtons(missedOther1Opts, OptionsEnum.SWEEP_ERROR)}
+                {this.renderRadioButtons(missedOther2Opts, OptionsEnum.LINE_ERROR)}
               </View>
             </View>
           </View>

--- a/components/StartGame/Styles.js
+++ b/components/StartGame/Styles.js
@@ -11,9 +11,8 @@ const styles = StyleSheet.create({
   optionContainer: {
     backgroundColor: '#979799',
     borderRadius: 10,
-    height: hp('20%'),
     width: wp('90%'),
-    marginTop: hp('1.5%')
+    marginTop: hp('1.5%'),
   },
   optionTitle: {
     justifyContent: 'center',
@@ -36,13 +35,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   labelText: {
-    fontWeight: 'bold',
-    fontSize: wp('4%')
+    fontSize: wp('3.5%'),
+    lineHeight: hp('3.4%'),
+    color: 'white'
   },
   missedOptionContainer: {
     backgroundColor: '#979799',
     borderRadius: 10,
-    height: hp('64%'),
     width: wp('90%'),
     marginTop: hp('1.5%')
   },


### PR DESCRIPTION
# Purpose

To fix the text cut-off on tablets. This led to changing the radio buttons to the more customizable version, which gives us better control of styling and allows us to scale the radio buttons with screen size. Since this introduced a lot of redundant code I decided to refactor the file a lot to make it cleaner. 

Also the grey containers now grow with content so it looks consistent on all devices!

# Notes:

Header text and labels are slightly off-center now - needs some styling tweaks.

I feel like there may be a better way to handle setting state and returning state in the renderRadioButtons function so some feedback or changes would be appreciated.

# Testing Performed

Tested on my iOS tablet and phone. Android testing and other device size testing would be helpful!